### PR TITLE
chore: add dependabot cooldown configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,12 @@ updates:
           - "patch"
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Adds `cooldown: default-days: 7` to all Dependabot update entries
- Delays version updates by 7 days after release to reduce risk of regressions and supply chain attacks
- Does not affect security updates (those still come immediately)

Ref: https://docs.zizmor.sh/audits/#dependabot-cooldown